### PR TITLE
fix: switch to bundler

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,11 +73,11 @@
     "json5": "^2.2.3"
   },
   "peerDependencies": {
-    "@codemirror/language": "^6.8.0",
+    "@codemirror/language": "^6.10.1",
     "@codemirror/lint": "^6.4.0",
     "@codemirror/state": "^6.2.1",
     "@codemirror/view": "^6.14.1",
-    "@lezer/common": "^1.0.3"
+    "@lezer/common": "^0.16.0"
   },
   "devDependencies": {
     "@changesets/cli": "^2.26.2",
@@ -90,10 +90,9 @@
     "@codemirror/theme-one-dark": "^6.1.2",
     "@codemirror/view": "^6.14.1",
     "@evilmartians/lefthook": "^1.4.6",
-    "@lezer/common": "^1.0.3",
+    "@lezer/common": "^1.2.1",
     "@types/markdown-it": "^13.0.7",
     "@vitest/coverage-v8": "^0.34.6",
-    "codemirror": "^6.0.1",
     "codemirror-json5": "^1.0.3",
     "happy-dom": "^10.3.2",
     "json5": "^2.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,7 +50,7 @@ devDependencies:
     version: 2.26.2
   '@codemirror/autocomplete':
     specifier: ^6.8.1
-    version: 6.8.1(@codemirror/language@6.8.0)(@codemirror/state@6.2.1)(@codemirror/view@6.14.1)(@lezer/common@1.0.3)
+    version: 6.8.1(@codemirror/language@6.8.0)(@codemirror/state@6.2.1)(@codemirror/view@6.14.1)(@lezer/common@1.2.1)
   '@codemirror/basic-setup':
     specifier: ^0.20.0
     version: 0.20.0
@@ -76,17 +76,14 @@ devDependencies:
     specifier: ^1.4.6
     version: 1.4.6
   '@lezer/common':
-    specifier: ^1.0.3
-    version: 1.0.3
+    specifier: ^1.2.1
+    version: 1.2.1
   '@types/markdown-it':
     specifier: ^13.0.7
     version: 13.0.7
   '@vitest/coverage-v8':
     specifier: ^0.34.6
     version: 0.34.6(vitest@0.34.6)
-  codemirror:
-    specifier: ^6.0.1
-    version: 6.0.1(@lezer/common@1.0.3)
   happy-dom:
     specifier: ^10.3.2
     version: 10.3.2
@@ -363,20 +360,6 @@ packages:
       '@lezer/common': 0.16.1
     dev: true
 
-  /@codemirror/autocomplete@6.8.1(@codemirror/language@6.8.0)(@codemirror/state@6.2.1)(@codemirror/view@6.14.1)(@lezer/common@1.0.3):
-    resolution: {integrity: sha512-HpphvDcTdOx+9R3eUw9hZK9JA77jlaBF0kOt2McbyfvY0rX9pnMoO8rkkZc0GzSbzhIY4m5xJ0uHHgjfqHNmXQ==}
-    peerDependencies:
-      '@codemirror/language': ^6.0.0
-      '@codemirror/state': ^6.0.0
-      '@codemirror/view': ^6.0.0
-      '@lezer/common': ^1.0.0
-    dependencies:
-      '@codemirror/language': 6.8.0
-      '@codemirror/state': 6.2.1
-      '@codemirror/view': 6.14.1
-      '@lezer/common': 1.0.3
-    dev: true
-
   /@codemirror/autocomplete@6.8.1(@codemirror/language@6.8.0)(@codemirror/state@6.2.1)(@codemirror/view@6.14.1)(@lezer/common@1.2.1):
     resolution: {integrity: sha512-HpphvDcTdOx+9R3eUw9hZK9JA77jlaBF0kOt2McbyfvY0rX9pnMoO8rkkZc0GzSbzhIY4m5xJ0uHHgjfqHNmXQ==}
     peerDependencies:
@@ -389,7 +372,6 @@ packages:
       '@codemirror/state': 6.2.1
       '@codemirror/view': 6.14.1
       '@lezer/common': 1.2.1
-    dev: false
 
   /@codemirror/basic-setup@0.20.0:
     resolution: {integrity: sha512-W/ERKMLErWkrVLyP5I8Yh8PXl4r+WFNkdYVSzkXYPQv2RMPSkWpr2BgggiSJ8AHF/q3GuApncDD8I4BZz65fyg==}
@@ -419,7 +401,7 @@ packages:
       '@codemirror/language': 6.8.0
       '@codemirror/state': 6.2.1
       '@codemirror/view': 6.14.1
-      '@lezer/common': 1.0.3
+      '@lezer/common': 1.2.1
     dev: true
 
   /@codemirror/lang-json@6.0.1:
@@ -459,9 +441,9 @@ packages:
     dependencies:
       '@codemirror/state': 6.2.1
       '@codemirror/view': 6.14.1
-      '@lezer/common': 1.0.3
+      '@lezer/common': 1.2.1
       '@lezer/highlight': 1.1.6
-      '@lezer/lr': 1.3.9
+      '@lezer/lr': 1.4.1
       style-mod: 4.0.3
 
   /@codemirror/lint@0.20.3:
@@ -485,14 +467,6 @@ packages:
     dependencies:
       '@codemirror/state': 0.20.1
       '@codemirror/view': 0.20.7
-      crelt: 1.0.6
-    dev: true
-
-  /@codemirror/search@6.5.0:
-    resolution: {integrity: sha512-64/M40YeJPToKvGO6p3fijo2vwUEj4nACEAXElCaYQ50HrXSvRaK+NHEhSh73WFBGdvIdhrV+lL9PdJy2RfCYA==}
-    dependencies:
-      '@codemirror/state': 6.2.1
-      '@codemirror/view': 6.14.1
       crelt: 1.0.6
     dev: true
 
@@ -783,12 +757,8 @@ packages:
     resolution: {integrity: sha512-qPmG7YTZ6lATyTOAWf8vXE+iRrt1NJd4cm2nJHK+v7X9TsOF6+HtuU/ctaZy2RCrluxDb89hI6KWQ5LfQGQWuA==}
     dev: true
 
-  /@lezer/common@1.0.3:
-    resolution: {integrity: sha512-JH4wAXCgUOcCGNekQPLhVeUtIqjH0yPBs7vvUdSjyQama9618IOKFJwkv2kcqdhF0my8hQEgCTEJU0GIgnahvA==}
-
   /@lezer/common@1.2.1:
     resolution: {integrity: sha512-yemX0ZD2xS/73llMZIK6KplkjIjf2EvAHcinDi/TfJ9hS25G0388+ClHt6/3but0oOxinTcQHJLDXh6w1crzFQ==}
-    dev: false
 
   /@lezer/highlight@0.16.0:
     resolution: {integrity: sha512-iE5f4flHlJ1g1clOStvXNLbORJoiW4Kytso6ubfYzHnaNo/eo5SKhxs4wv/rtvwZQeZrK3we8S9SyA7OGOoRKQ==}
@@ -799,14 +769,14 @@ packages:
   /@lezer/highlight@1.1.6:
     resolution: {integrity: sha512-cmSJYa2us+r3SePpRCjN5ymCqCPv+zyXmDl0ciWtVaNiORT/MxM7ZgOMQZADD0o51qOaOg24qc/zBViOIwAjJg==}
     dependencies:
-      '@lezer/common': 1.0.3
+      '@lezer/common': 1.2.1
 
   /@lezer/json@1.0.1:
     resolution: {integrity: sha512-nkVC27qiEZEjySbi6gQRuMwa2sDu2PtfjSgz0A4QF81QyRGm3kb2YRzLcOPcTEtmcwvrX/cej7mlhbwViA4WJw==}
     requiresBuild: true
     dependencies:
       '@lezer/highlight': 1.1.6
-      '@lezer/lr': 1.3.9
+      '@lezer/lr': 1.4.1
     dev: false
     optional: true
 
@@ -816,23 +786,17 @@ packages:
       '@lezer/common': 0.16.1
     dev: true
 
-  /@lezer/lr@1.3.9:
-    resolution: {integrity: sha512-XPz6dzuTHlnsbA5M2DZgjflNQ+9Hi5Swhic0RULdp3oOs3rh6bqGZolosVqN/fQIT8uNiepzINJDnS39oweTHQ==}
-    dependencies:
-      '@lezer/common': 1.0.3
-
-  /@lezer/lr@1.4.0:
-    resolution: {integrity: sha512-Wst46p51km8gH0ZUmeNrtpRYmdlRHUpN1DQd3GFAyKANi8WVz8c2jHYTf1CVScFaCjQw1iO3ZZdqGDxQPRErTg==}
+  /@lezer/lr@1.4.1:
+    resolution: {integrity: sha512-CHsKq8DMKBf9b3yXPDIU4DbH+ZJd/sJdYOW2llbW/HudP5u0VS6Bfq1hLYfgU7uAYGFIyGGQIsSOXGPEErZiJw==}
     dependencies:
       '@lezer/common': 1.2.1
-    dev: false
 
   /@lezer/yaml@1.0.2:
     resolution: {integrity: sha512-XCkwuxe+eumJ28nA9e1S6XKsXz9W7V/AG+WBiWOtiIuUpKcZ/bHuvN8bLxSDREIcybSRpEd/jvphh4vgm6Ed2g==}
     dependencies:
       '@lezer/common': 1.2.1
       '@lezer/highlight': 1.1.6
-      '@lezer/lr': 1.4.0
+      '@lezer/lr': 1.4.1
     dev: false
 
   /@manypkg/find-root@1.1.0:
@@ -1258,26 +1222,12 @@ packages:
       '@codemirror/language': 6.8.0
       '@codemirror/state': 6.2.1
       '@codemirror/view': 6.14.1
-      '@lezer/common': 1.0.3
+      '@lezer/common': 1.2.1
       '@lezer/highlight': 1.1.6
       json5: 2.2.3
       lezer-json5: 2.0.2
     dev: false
     optional: true
-
-  /codemirror@6.0.1(@lezer/common@1.0.3):
-    resolution: {integrity: sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==}
-    dependencies:
-      '@codemirror/autocomplete': 6.8.1(@codemirror/language@6.8.0)(@codemirror/state@6.2.1)(@codemirror/view@6.14.1)(@lezer/common@1.0.3)
-      '@codemirror/commands': 6.2.4
-      '@codemirror/language': 6.8.0
-      '@codemirror/lint': 6.4.0
-      '@codemirror/search': 6.5.0
-      '@codemirror/state': 6.2.1
-      '@codemirror/view': 6.14.1
-    transitivePeerDependencies:
-      - '@lezer/common'
-    dev: true
 
   /color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
@@ -2162,7 +2112,7 @@ packages:
     resolution: {integrity: sha512-NRmtBlKW/f8mA7xatKq8IUOq045t8GVHI4kZXrUtYYUdiVeGiO6zKGAV7/nUAnf5q+rYTY+SWX/gvQdFXMjNxQ==}
     requiresBuild: true
     dependencies:
-      '@lezer/lr': 1.3.9
+      '@lezer/lr': 1.4.1
     dev: false
     optional: true
 

--- a/src/json-completion.ts
+++ b/src/json-completion.ts
@@ -55,7 +55,7 @@ export class JSONCompletion {
   private schema: JSONSchema7 | null = null;
   private mode: JSONMode = MODES.JSON;
   constructor(private opts: JSONCompletionOptions) {
-    this.mode = opts.mode ?? MODES.JSON;
+    this.mode = this.opts.mode ?? MODES.JSON;
   }
   public doComplete(ctx: CompletionContext) {
     const s = getJSONSchema(ctx.state)!;
@@ -918,9 +918,9 @@ export class JSONCompletion {
     }
   }
 
-  private getValueFromLabel(value: any): string {
-    return JSON.parse(value);
-  }
+  // private getValueFromLabel(value: any): string {
+  //   return JSON.parse(value);
+  // }
 
   private extendedRegExp(pattern: string): RegExp | undefined {
     let flags = "";

--- a/src/json-validation.ts
+++ b/src/json-validation.ts
@@ -4,7 +4,7 @@ import { Draft04, type Draft, type JsonError } from "json-schema-library";
 
 import { getJSONSchema, schemaStateField } from "./state.js";
 import { joinWithOr } from "./utils/formatting.js";
-import { JSONMode, JSONPointerData, RequiredPick } from "./types.js";
+import { JSONMode, JSONPointerData } from "./types.js";
 import { parseJSONDocumentState } from "./utils/parseJSONDocument.js";
 import { el } from "./utils/dom.js";
 import { renderMarkdown } from "./utils/markdown.js";
@@ -43,7 +43,7 @@ export interface JSONValidationOptions {
   jsonParser?: typeof parseJSONDocumentState;
 }
 
-type JSONValidationSettings = RequiredPick<JSONValidationOptions, "jsonParser">;
+// type JSONValidationSettings = RequiredPick<JSONValidationOptions, "jsonParser">;
 
 export const handleRefresh = (vu: ViewUpdate) => {
   return (

--- a/src/json5/completion.ts
+++ b/src/json5/completion.ts
@@ -1,6 +1,6 @@
 import { CompletionContext } from "@codemirror/autocomplete";
-import { MODES } from "../constants";
-import { JSONCompletion, JSONCompletionOptions } from "../json-completion";
+import { MODES } from "../constants.js";
+import { JSONCompletion, JSONCompletionOptions } from "../json-completion.js";
 
 /**
  * provides a JSON schema enabled autocomplete extension for codemirror and json5

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { MODES } from "./constants";
+import { MODES } from "./constants.js";
 
 export type RequiredPick<T, F extends keyof T> = Omit<T, F> &
   Required<Pick<T, F>>;

--- a/src/utils/parse-yaml-document.ts
+++ b/src/utils/parse-yaml-document.ts
@@ -2,7 +2,6 @@
  * Mimics the behavior of `json-source-map`'s `parseJSONDocument` function using codemirror EditorState... for YAML
  */
 
-import { yaml } from "@codemirror/lang-yaml";
 import YAML from "yaml";
 import { EditorState } from "@codemirror/state";
 import { getJsonPointers } from "./jsonPointers.js";

--- a/src/yaml/completion.ts
+++ b/src/yaml/completion.ts
@@ -1,6 +1,6 @@
 import { CompletionContext } from "@codemirror/autocomplete";
-import { MODES } from "../constants";
-import { JSONCompletion, JSONCompletionOptions } from "../json-completion";
+import { MODES } from "../constants.js";
+import { JSONCompletion, JSONCompletionOptions } from "../json-completion.js";
 
 /**
  * provides a JSON schema enabled autocomplete extension for codemirror and yaml

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,14 +6,15 @@
     "strict": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "moduleResolution": "Node",
+    "moduleResolution": "Bundler",
     "lib": ["ESNext", "DOM"],
     "declaration": true,
     "resolveJsonModule": true,
     "removeComments": false,
-    "isolatedModules": true
+    "isolatedModules": true,
+    "stripInternal": true,
+    "noUnusedLocals": true
   },
-  "compileOnSave": true,
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "**/__tests__/**"]
+  "exclude": ["node_modules/**", "**/__tests__/**"]
 }


### PR DESCRIPTION
experimenting with whether this will fix some of the bundling issues.

`moduleResolution: "nodenext"` was just not working for our dependencies, and workarounds were not effective for `@codemirror/*` projects which are bundled with `cm-buildhelper` [which appears to use `moduleResolution: 'node'`](https://github.com/codemirror/dev/blob/main/tsconfig.json)


