### PR TITLE
fix demo highlighting

### DIFF
--- a/.changeset/funny-ligers-call.md
+++ b/.changeset/funny-ligers-call.md
@@ -1,0 +1,5 @@
+---
+"codemirror-json-schema": patch
+---
+
+fix demo highlighting

--- a/dev/index.ts
+++ b/dev/index.ts
@@ -1,4 +1,4 @@
-import { EditorState, StateEffect, StateField } from "@codemirror/state";
+import { EditorState } from "@codemirror/state";
 import {
   gutter,
   EditorView,
@@ -8,9 +8,7 @@ import {
   highlightActiveLineGutter,
   ViewUpdate,
 } from "@codemirror/view";
-// import { basicSetup } from "@codemirror/basic-setup";
-import { lintGutter } from "@codemirror/lint";
-import { lintKeymap } from "@codemirror/lint";
+import { lintKeymap, lintGutter } from "@codemirror/lint";
 import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
 import {
   syntaxHighlighting,

--- a/package.json
+++ b/package.json
@@ -69,28 +69,28 @@
     "yaml": "^2.3.4"
   },
   "optionalDependencies": {
-    "@codemirror/autocomplete": "^6.16.1",
+    "@codemirror/autocomplete": "^6.16.2",
     "@codemirror/lang-json": "^6.0.1",
-    "@codemirror/lang-yaml": "^6.0.0",
+    "@codemirror/lang-yaml": "^6.1.1",
     "codemirror-json5": "^1.0.3",
     "json5": "^2.2.3"
   },
   "peerDependencies": {
-    "@codemirror/language": "^6.8.0",
-    "@codemirror/lint": "^6.4.0",
-    "@codemirror/state": "^6.2.1",
-    "@codemirror/view": "^6.14.1",
-    "@lezer/common": "^1.0.3"
+    "@codemirror/language": "^6.10.2",
+    "@codemirror/lint": "^6.8.0",
+    "@codemirror/state": "^6.4.1",
+    "@codemirror/view": "^6.27.0",
+    "@lezer/common": "^1.2.1"
   },
   "devDependencies": {
     "@changesets/cli": "^2.26.2",
     "@codemirror/autocomplete": "^6.16.2",
-    "@codemirror/commands": "^6.5.0",
-    "@codemirror/language": "^6.10.1",
+    "@codemirror/commands": "^6.6.0",
+    "@codemirror/language": "^6.10.2",
     "@codemirror/lint": "^6.8.0",
     "@codemirror/state": "^6.4.1",
     "@codemirror/theme-one-dark": "^6.1.2",
-    "@codemirror/view": "^6.26.3",
+    "@codemirror/view": "^6.27.0",
     "@evilmartians/lefthook": "^1.4.6",
     "@lezer/common": "^1.2.1",
     "@types/markdown-it": "^13.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,14 +38,14 @@ dependencies:
 
 optionalDependencies:
   '@codemirror/autocomplete':
-    specifier: ^6.16.1
-    version: 6.16.1(@codemirror/language@6.10.1)(@codemirror/state@6.4.1)(@codemirror/view@6.26.3)(@lezer/common@1.2.1)
+    specifier: ^6.16.2
+    version: 6.16.2(@codemirror/language@6.10.2)(@codemirror/state@6.4.1)(@codemirror/view@6.27.0)(@lezer/common@1.2.1)
   '@codemirror/lang-json':
     specifier: ^6.0.1
     version: 6.0.1
   '@codemirror/lang-yaml':
-    specifier: ^6.0.0
-    version: 6.1.1(@codemirror/view@6.26.3)
+    specifier: ^6.1.1
+    version: 6.1.1(@codemirror/view@6.27.0)
   codemirror-json5:
     specifier: ^1.0.3
     version: 1.0.3
@@ -58,11 +58,11 @@ devDependencies:
     specifier: ^2.26.2
     version: 2.26.2
   '@codemirror/commands':
-    specifier: ^6.5.0
-    version: 6.5.0
+    specifier: ^6.6.0
+    version: 6.6.0
   '@codemirror/language':
-    specifier: ^6.10.1
-    version: 6.10.1
+    specifier: ^6.10.2
+    version: 6.10.2
   '@codemirror/lint':
     specifier: ^6.8.0
     version: 6.8.0
@@ -73,8 +73,8 @@ devDependencies:
     specifier: ^6.1.2
     version: 6.1.2
   '@codemirror/view':
-    specifier: ^6.26.3
-    version: 6.26.3
+    specifier: ^6.27.0
+    version: 6.27.0
   '@evilmartians/lefthook':
     specifier: ^1.4.6
     version: 1.4.6
@@ -354,28 +354,27 @@ packages:
       prettier: 2.8.8
     dev: true
 
-  /@codemirror/autocomplete@6.16.1(@codemirror/language@6.10.1)(@codemirror/state@6.4.1)(@codemirror/view@6.26.3)(@lezer/common@1.2.1):
-    resolution: {integrity: sha512-A8ouvLbTi9rGNhdmqRuj0ohY7pSWwO4iK3DdiIhWvUjI8T9Yiqul6t8z9warW8nFq2fyW1Pr+KZWZhuQL+iOqg==}
-    requiresBuild: true
+  /@codemirror/autocomplete@6.16.2(@codemirror/language@6.10.2)(@codemirror/state@6.4.1)(@codemirror/view@6.27.0)(@lezer/common@1.2.1):
+    resolution: {integrity: sha512-MjfDrHy0gHKlPWsvSsikhO1+BOh+eBHNgfH1OXs1+DAf30IonQldgMM3kxLDTG9ktE7kDLaA1j/l7KMPA4KNfw==}
     peerDependencies:
       '@codemirror/language': ^6.0.0
       '@codemirror/state': ^6.0.0
       '@codemirror/view': ^6.0.0
       '@lezer/common': ^1.0.0
     dependencies:
-      '@codemirror/language': 6.10.1
+      '@codemirror/language': 6.10.2
       '@codemirror/state': 6.4.1
-      '@codemirror/view': 6.26.3
+      '@codemirror/view': 6.27.0
       '@lezer/common': 1.2.1
     dev: false
     optional: true
 
-  /@codemirror/commands@6.5.0:
-    resolution: {integrity: sha512-rK+sj4fCAN/QfcY9BEzYMgp4wwL/q5aj/VfNSoH1RWPF9XS/dUwBkvlL3hpWgEjOqlpdN1uLC9UkjJ4tmyjJYg==}
+  /@codemirror/commands@6.6.0:
+    resolution: {integrity: sha512-qnY+b7j1UNcTS31Eenuc/5YJB6gQOzkUoNmJQc0rznwqSRpeaWWpjkWy2C/MPTcePpsKJEM26hXrOXl1+nceXg==}
     dependencies:
-      '@codemirror/language': 6.10.1
+      '@codemirror/language': 6.10.2
       '@codemirror/state': 6.4.1
-      '@codemirror/view': 6.26.3
+      '@codemirror/view': 6.27.0
       '@lezer/common': 1.2.1
     dev: true
 
@@ -383,17 +382,17 @@ packages:
     resolution: {integrity: sha512-+T1flHdgpqDDlJZ2Lkil/rLiRy684WMLc74xUnjJH48GQdfJo/pudlTRreZmKwzP8/tGdKf83wlbAdOCzlJOGQ==}
     requiresBuild: true
     dependencies:
-      '@codemirror/language': 6.10.1
+      '@codemirror/language': 6.10.2
       '@lezer/json': 1.0.1
     dev: false
     optional: true
 
-  /@codemirror/lang-yaml@6.1.1(@codemirror/view@6.26.3):
+  /@codemirror/lang-yaml@6.1.1(@codemirror/view@6.27.0):
     resolution: {integrity: sha512-HV2NzbK9bbVnjWxwObuZh5FuPCowx51mEfoFT9y3y+M37fA3+pbxx4I7uePuygFzDsAmCTwQSc/kXh/flab4uw==}
     requiresBuild: true
     dependencies:
-      '@codemirror/autocomplete': 6.16.1(@codemirror/language@6.10.1)(@codemirror/state@6.4.1)(@codemirror/view@6.26.3)(@lezer/common@1.2.1)
-      '@codemirror/language': 6.10.1
+      '@codemirror/autocomplete': 6.16.2(@codemirror/language@6.10.2)(@codemirror/state@6.4.1)(@codemirror/view@6.27.0)(@lezer/common@1.2.1)
+      '@codemirror/language': 6.10.2
       '@codemirror/state': 6.4.1
       '@lezer/common': 1.2.1
       '@lezer/highlight': 1.2.0
@@ -403,11 +402,11 @@ packages:
     dev: false
     optional: true
 
-  /@codemirror/language@6.10.1:
-    resolution: {integrity: sha512-5GrXzrhq6k+gL5fjkAwt90nYDmjlzTIJV8THnxNFtNKWotMIlzzN+CpqxqwXOECnUdOndmSeWntVrVcv5axWRQ==}
+  /@codemirror/language@6.10.2:
+    resolution: {integrity: sha512-kgbTYTo0Au6dCSc/TFy7fK3fpJmgHDv1sG1KNQKJXVi+xBTEeBPY/M30YXiU6mMXeH+YIDLsbrT4ZwNRdtF+SA==}
     dependencies:
       '@codemirror/state': 6.4.1
-      '@codemirror/view': 6.26.3
+      '@codemirror/view': 6.27.0
       '@lezer/common': 1.2.1
       '@lezer/highlight': 1.2.0
       '@lezer/lr': 1.4.0
@@ -417,7 +416,7 @@ packages:
     resolution: {integrity: sha512-lsFofvaw0lnPRJlQylNsC4IRt/1lI4OD/yYslrSGVndOJfStc58v+8p9dgGiD90ktOfL7OhBWns1ZETYgz0EJA==}
     dependencies:
       '@codemirror/state': 6.4.1
-      '@codemirror/view': 6.26.3
+      '@codemirror/view': 6.27.0
       crelt: 1.0.6
     dev: true
 
@@ -427,14 +426,14 @@ packages:
   /@codemirror/theme-one-dark@6.1.2:
     resolution: {integrity: sha512-F+sH0X16j/qFLMAfbciKTxVOwkdAS336b7AXTKOZhy8BR3eH/RelsnLgLFINrpST63mmN2OuwUt0W2ndUgYwUA==}
     dependencies:
-      '@codemirror/language': 6.10.1
+      '@codemirror/language': 6.10.2
       '@codemirror/state': 6.4.1
-      '@codemirror/view': 6.26.3
-      '@lezer/highlight': 1.1.6
+      '@codemirror/view': 6.27.0
+      '@lezer/highlight': 1.2.0
     dev: true
 
-  /@codemirror/view@6.26.3:
-    resolution: {integrity: sha512-gmqxkPALZjkgSxIeeweY/wGQXBfwTUaLs8h7OKtSwfbj9Ct3L11lD+u1sS7XHppxFQoMDiMDp07P9f3I2jWOHw==}
+  /@codemirror/view@6.27.0:
+    resolution: {integrity: sha512-8kqX1sHbVW1lVzWwrjAbh4dR7eKhV8eIQ952JKaBXOoXE04WncoqCy4DMU701LSrPZ3N2Q4zsTawz7GQ+2mrUw==}
     dependencies:
       '@codemirror/state': 6.4.1
       style-mod: 4.1.0
@@ -682,11 +681,6 @@ packages:
     resolution: {integrity: sha512-yemX0ZD2xS/73llMZIK6KplkjIjf2EvAHcinDi/TfJ9hS25G0388+ClHt6/3but0oOxinTcQHJLDXh6w1crzFQ==}
     requiresBuild: true
 
-  /@lezer/highlight@1.1.6:
-    resolution: {integrity: sha512-cmSJYa2us+r3SePpRCjN5ymCqCPv+zyXmDl0ciWtVaNiORT/MxM7ZgOMQZADD0o51qOaOg24qc/zBViOIwAjJg==}
-    dependencies:
-      '@lezer/common': 1.2.1
-
   /@lezer/highlight@1.2.0:
     resolution: {integrity: sha512-WrS5Mw51sGrpqjlh3d4/fOwpEV2Hd3YOkp9DBt4k8XZQcoTHZFB7sx030A6OcahF4J1nDQAa3jXlTVVYH50IFA==}
     requiresBuild: true
@@ -697,16 +691,8 @@ packages:
     resolution: {integrity: sha512-nkVC27qiEZEjySbi6gQRuMwa2sDu2PtfjSgz0A4QF81QyRGm3kb2YRzLcOPcTEtmcwvrX/cej7mlhbwViA4WJw==}
     requiresBuild: true
     dependencies:
-      '@lezer/highlight': 1.1.6
-      '@lezer/lr': 1.3.9
-    dev: false
-    optional: true
-
-  /@lezer/lr@1.3.9:
-    resolution: {integrity: sha512-XPz6dzuTHlnsbA5M2DZgjflNQ+9Hi5Swhic0RULdp3oOs3rh6bqGZolosVqN/fQIT8uNiepzINJDnS39oweTHQ==}
-    requiresBuild: true
-    dependencies:
-      '@lezer/common': 1.2.1
+      '@lezer/highlight': 1.2.0
+      '@lezer/lr': 1.4.0
     dev: false
     optional: true
 
@@ -1279,11 +1265,11 @@ packages:
     resolution: {integrity: sha512-HmmoYO2huQxoaoG5ARKjqQc9mz7/qmNPvMbISVfIE2Gk1+4vZQg9X3G6g49MYM5IK00Ol3aijd7OKrySuOkA7Q==}
     requiresBuild: true
     dependencies:
-      '@codemirror/language': 6.10.1
+      '@codemirror/language': 6.10.2
       '@codemirror/state': 6.4.1
-      '@codemirror/view': 6.26.3
+      '@codemirror/view': 6.27.0
       '@lezer/common': 1.2.1
-      '@lezer/highlight': 1.1.6
+      '@lezer/highlight': 1.2.0
       json5: 2.2.3
       lezer-json5: 2.0.2
     dev: false
@@ -1746,6 +1732,7 @@ packages:
 
   /glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Glob versions prior to v9 are no longer supported
     dependencies:
       fs.realpath: 1.0.0
       inflight: 1.0.6
@@ -1908,6 +1895,7 @@ packages:
 
   /inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
@@ -2174,7 +2162,7 @@ packages:
     resolution: {integrity: sha512-NRmtBlKW/f8mA7xatKq8IUOq045t8GVHI4kZXrUtYYUdiVeGiO6zKGAV7/nUAnf5q+rYTY+SWX/gvQdFXMjNxQ==}
     requiresBuild: true
     dependencies:
-      '@lezer/lr': 1.3.9
+      '@lezer/lr': 1.4.0
     dev: false
     optional: true
 
@@ -2227,6 +2215,7 @@ packages:
 
   /loupe@2.3.6:
     resolution: {integrity: sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==}
+    deprecated: Please upgrade to 2.3.7 which fixes GHSA-4q6p-r6v2-jvc5
     dependencies:
       get-func-name: 2.0.2
     dev: true

--- a/src/features/validation.ts
+++ b/src/features/validation.ts
@@ -128,7 +128,7 @@ export class JSONValidation {
     const text = view.state.doc.toString();
 
     // ignore blank json strings
-    if (!text || !text.length) return [];
+    if (!text?.length) return [];
 
     const json = this.parser(view.state);
 


### PR DESCRIPTION
Codemirror misbehaves when relevant package versions are out of sync, or if there are multiple versions of the same package being used. I updated all the packages to the latest versions, and [deduped](https://pnpm.io/cli/dedupe) to remove any duplicated package versions