### PR TITLE
updated json-schema-library to get upstream fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@types/json-schema": "^7.0.12",
     "@types/node": "^20.4.2",
     "json-schema": "^0.4.0",
-    "json-schema-library": "^9.1.2",
+    "json-schema-library": "^9.3.5",
     "markdown-it": "^14.0.0",
     "vite-tsconfig-paths": "^4.3.1",
     "yaml": "^2.3.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ dependencies:
     specifier: ^0.4.0
     version: 0.4.0
   json-schema-library:
-    specifier: ^9.1.2
-    version: 9.1.2
+    specifier: ^9.3.5
+    version: 9.3.5
   markdown-it:
     specifier: ^14.0.0
     version: 14.0.0
@@ -883,10 +883,14 @@ packages:
     resolution: {integrity: sha512-/iskWuyGNu09qy09HYmyLnvzpKryymH9T+vTBi2LdFp1TuKvERDADvPMv2ZkQKsrRklOzivmOz9QXof0dKqvgA==}
     dev: false
 
-  /@sagold/json-query@6.1.1:
-    resolution: {integrity: sha512-5/Wu0rTnXmO5Uvtm9Of16Vx3mKjSnYA0Um9LgBtyPhIucYlppKgKC4N3g8gD0Fk00a5kizQTs4gwxKPXCpmeww==}
+  /@sagold/json-pointer@5.1.2:
+    resolution: {integrity: sha512-+wAhJZBXa6MNxRScg6tkqEbChEHMgVZAhTHVJ60Y7sbtXtu9XA49KfUkdWlS2x78D6H9nryiKePiYozumauPfA==}
+    dev: false
+
+  /@sagold/json-query@6.2.0:
+    resolution: {integrity: sha512-7bOIdUE6eHeoWtFm8TvHQHfTVSZuCs+3RpOKmZCDBIOrxpvF/rNFTeuvIyjHva/RR0yVS3kQtr+9TW72LQEZjA==}
     dependencies:
-      '@sagold/json-pointer': 5.1.1
+      '@sagold/json-pointer': 5.1.2
       ebnf: 1.9.1
     dev: false
 
@@ -1603,8 +1607,8 @@ packages:
       tmp: 0.0.33
     dev: true
 
-  /fast-copy@3.0.1:
-    resolution: {integrity: sha512-Knr7NOtK3HWRYGtHoJrjkaWepqT8thIVGAwt0p0aUs1zqkAzXZV4vo9fFNwyb5fcqK1GKYFYxldQdIDVKhUAfA==}
+  /fast-copy@3.0.2:
+    resolution: {integrity: sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==}
     dev: false
 
   /fast-deep-equal@3.1.3:
@@ -2126,13 +2130,13 @@ packages:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
     dev: true
 
-  /json-schema-library@9.1.2:
-    resolution: {integrity: sha512-uQnFb2V+VakLl6XIGGtUQzfjkP31f/dCT5lJq9NOUdypSSpjbWL/V0R2KvoNJp3hU8VErwh9DqVoZPqlC+B3IA==}
+  /json-schema-library@9.3.5:
+    resolution: {integrity: sha512-5eBDx7cbfs+RjylsVO+N36b0GOPtv78rfqgf2uON+uaHUIC62h63Y8pkV2ovKbaL4ZpQcHp21968x5nx/dFwqQ==}
     dependencies:
-      '@sagold/json-pointer': 5.1.1
-      '@sagold/json-query': 6.1.1
+      '@sagold/json-pointer': 5.1.2
+      '@sagold/json-query': 6.2.0
       deepmerge: 4.3.1
-      fast-copy: 3.0.1
+      fast-copy: 3.0.2
       fast-deep-equal: 3.1.3
       smtp-address-parser: 1.0.10
       valid-url: 1.0.9


### PR DESCRIPTION
Some issues (#89, #69) have been fixed upstream in json-schema-library. We just need to use the updated version to get these issues resolved.