### PR TITLE
added limited support for conditional property values

### DIFF
--- a/.changeset/nine-timers-develop.md
+++ b/.changeset/nine-timers-develop.md
@@ -1,0 +1,5 @@
+---
+"codemirror-json-schema": patch
+---
+
+added limited support for conditional property values

--- a/src/features/__tests__/__fixtures__/schemas.ts
+++ b/src/features/__tests__/__fixtures__/schemas.ts
@@ -140,7 +140,7 @@ export const testSchemaConditionalProperties = {
   properties: {
     type: {
       type: "string",
-      enum: ["Test_1", "Test_2"],
+      enum: ["Test_1", "Test_2", "Test_3"],
     },
     props: {
       type: "object",
@@ -178,6 +178,18 @@ export const testSchemaConditionalProperties = {
             },
             additionalProperties: false,
           },
+        },
+      },
+    },
+    {
+      if: {
+        properties: {
+          type: { const: "Test_3" },
+        },
+      },
+      then: {
+        properties: {
+          props: { type: "string", enum: ["ace", "abu", "bay"] },
         },
       },
     },

--- a/src/features/__tests__/json-completion.spec.ts
+++ b/src/features/__tests__/json-completion.spec.ts
@@ -409,6 +409,24 @@ describe.each([
     ],
     schema: testSchemaConditionalProperties,
   },
+  {
+    name: "autocomplete for a schema with conditional property values",
+    mode: MODES.JSON,
+    docs: ['{ "type": "Test_3", "props": "a|"'],
+    expectedResults: [
+      {
+        type: "string",
+        label: "ace",
+        apply: '"ace"',
+      },
+      {
+        type: "string",
+        label: "abu",
+        apply: '"abu"',
+      },
+    ],
+    schema: testSchemaConditionalProperties,
+  },
   // JSON5
   {
     name: "return bare property key when no quotes are used",


### PR DESCRIPTION
As mentioned in #129 we don't get fully resolved schemas based on the data. Following the discussion in https://github.com/sagold/json-schema-library/issues/61, that appears to be expected.

The workaround I implemented is to "fake" a deep schema resolution by performing the shallow schema resolution on the direct children properties of the schema (we only really care about the direct children in this context).