### PR TITLE
Fix description markdown rendering in completion

### DIFF
--- a/.changeset/rich-tables-hug.md
+++ b/.changeset/rich-tables-hug.md
@@ -1,0 +1,5 @@
+---
+"codemirror-json-schema": patch
+---
+
+Fix description markdown rendering in completion

--- a/src/features/__tests__/__helpers__/completion.ts
+++ b/src/features/__tests__/__helpers__/completion.ts
@@ -66,7 +66,10 @@ export async function expectCompletion(
   }
   const filteredResults = result.options.map((item) => ({
     detail: item.detail,
-    info: item.info,
+    info:
+      typeof item.info === "function"
+        ? (item.info(item) as HTMLElement).innerText
+        : item.info,
     label: item.label,
     type: item.type,
     apply: typeof item.apply === "string" ? item.apply : undefined,

--- a/src/features/completion.ts
+++ b/src/features/completion.ts
@@ -30,6 +30,7 @@ import {
 } from "../utils/json-pointers";
 import { MODES, TOKENS } from "../constants";
 import { JSONMode } from "../types";
+import { el } from "../utils/dom";
 import { renderMarkdown } from "../utils/markdown";
 import { DocumentParser, getDefaultParser } from "../parsers";
 
@@ -308,7 +309,10 @@ export class JSONCompletion {
               ),
               type: "property",
               detail: typeStr,
-              info: renderMarkdown(description),
+              info: () =>
+                el("div", {
+                  inner: renderMarkdown(description),
+                }),
             };
             collector.add(this.applySnippetCompletion(completion));
           }


### PR DESCRIPTION
Before this, markdown-rendered HTML from description was rendered as plain text.

To test, use the demo with tsconfig.json schema and type a new property `ts` to trigger completion for `ts-node`, which description contains a link.